### PR TITLE
feat: add VEX Forum integration with 6 new tools

### DIFF
--- a/src/handlers/forum-handlers.ts
+++ b/src/handlers/forum-handlers.ts
@@ -1,0 +1,413 @@
+/**
+ * Forum-related request handlers for MCP tools
+ */
+
+import { vexForumClient } from "../utils/discourse-client.js";
+import { createTextResponse, createErrorResponse, truncateText } from "../utils/response-formatter.js";
+
+// Type definitions for handler parameters
+export interface SearchForumParams {
+  query: string;
+  category?: string;
+  user?: string;
+  order?: "latest" | "likes" | "views" | "latest_topic";
+  before?: string;
+  after?: string;
+  max_results?: number;
+}
+
+export interface GetForumTopicParams {
+  topic_id: number;
+  max_posts?: number;
+  include_raw?: boolean;
+}
+
+export interface GetForumPostParams {
+  post_id: number;
+}
+
+export interface GetForumUserParams {
+  username: string;
+}
+
+export interface ListForumCategoriesParams {}
+
+export interface GetLatestForumTopicsParams {
+  category_slug?: string;
+  category_id?: number;
+  page?: number;
+  max_results?: number;
+}
+
+/**
+ * Strip HTML tags from content for cleaner text output
+ */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, "") // Remove HTML tags
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n\s*\n/g, "\n\n") // Collapse multiple newlines
+    .trim();
+}
+
+/**
+ * Format a date string to a readable format
+ */
+function formatDate(dateString: string): string {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return dateString;
+  }
+}
+
+export class ForumHandlers {
+  /**
+   * Handles search-forum tool requests
+   */
+  static async handleSearchForum(args: SearchForumParams) {
+    try {
+      const maxResults = Math.min(args.max_results || 10, 50);
+
+      const result = await vexForumClient.search(args.query, {
+        category: args.category,
+        user: args.user,
+        order: args.order,
+        before: args.before,
+        after: args.after,
+      });
+
+      const topics = result.topics || [];
+      const posts = result.posts || [];
+
+      if (topics.length === 0 && posts.length === 0) {
+        return createTextResponse(`No results found for "${args.query}"`);
+      }
+
+      let responseText = `**Search Results for "${args.query}"**\n\n`;
+
+      // Format topics
+      if (topics.length > 0) {
+        responseText += `### Topics (${topics.length} found)\n\n`;
+        const displayTopics = topics.slice(0, maxResults);
+
+        for (const topic of displayTopics) {
+          responseText +=
+            `**[${topic.title}](https://www.vexforum.com/t/${topic.slug}/${topic.id})**\n` +
+            `- Views: ${topic.views} | Replies: ${topic.reply_count} | Likes: ${topic.like_count}\n` +
+            `- Created: ${formatDate(topic.created_at)}` +
+            (topic.tags && topic.tags.length > 0 ? ` | Tags: ${topic.tags.join(", ")}` : "") +
+            `\n\n`;
+        }
+
+        if (topics.length > maxResults) {
+          responseText += `*... and ${topics.length - maxResults} more topics*\n\n`;
+        }
+      }
+
+      // Format posts with blurbs
+      if (posts.length > 0) {
+        responseText += `### Matching Posts (${posts.length} found)\n\n`;
+        const displayPosts = posts.slice(0, maxResults);
+
+        for (const post of displayPosts) {
+          const blurb = truncateText(stripHtml(post.blurb), 200);
+          responseText +=
+            `**${post.topic_title_headline || "Post"}** by @${post.username}\n` +
+            `> ${blurb}\n` +
+            `- [View Post](https://www.vexforum.com/t/-/${post.topic_id}/${post.post_number}) | ` +
+            `Likes: ${post.like_count} | Posted: ${formatDate(post.created_at)}\n\n`;
+        }
+
+        if (posts.length > maxResults) {
+          responseText += `*... and ${posts.length - maxResults} more posts*\n\n`;
+        }
+      }
+
+      return createTextResponse(responseText);
+    } catch (error) {
+      return createErrorResponse(error, "searching VEX Forum");
+    }
+  }
+
+  /**
+   * Handles get-forum-topic tool requests
+   */
+  static async handleGetForumTopic(args: GetForumTopicParams) {
+    try {
+      const maxPosts = Math.min(args.max_posts || 10, 50);
+
+      const topic = await vexForumClient.getTopic(args.topic_id, {
+        include_raw: args.include_raw,
+      });
+
+      let responseText =
+        `**${topic.title}**\n` +
+        `[View on VEX Forum](https://www.vexforum.com/t/${topic.slug}/${topic.id})\n\n` +
+        `- **Views:** ${topic.views}\n` +
+        `- **Replies:** ${topic.reply_count}\n` +
+        `- **Likes:** ${topic.like_count}\n` +
+        `- **Created:** ${formatDate(topic.created_at)}\n` +
+        `- **Last Activity:** ${formatDate(topic.last_posted_at)}\n` +
+        (topic.tags && topic.tags.length > 0 ? `- **Tags:** ${topic.tags.join(", ")}\n` : "") +
+        (topic.closed ? `- **Status:** Closed\n` : "") +
+        (topic.archived ? `- **Status:** Archived\n` : "");
+
+      // Add participant info if available
+      if (topic.details?.participants && topic.details.participants.length > 0) {
+        const topParticipants = topic.details.participants
+          .slice(0, 5)
+          .map((p) => `@${p.username} (${p.post_count} posts)`)
+          .join(", ");
+        responseText += `- **Top Participants:** ${topParticipants}\n`;
+      }
+
+      responseText += "\n---\n\n";
+
+      // Add posts
+      const posts = topic.post_stream?.posts || [];
+      const displayPosts = posts.slice(0, maxPosts);
+
+      responseText += `### Posts (showing ${displayPosts.length} of ${posts.length})\n\n`;
+
+      for (const post of displayPosts) {
+        const content = args.include_raw && post.raw
+          ? post.raw
+          : stripHtml(post.cooked);
+
+        const truncatedContent = truncateText(content, 1500);
+
+        responseText +=
+          `#### Post #${post.post_number} by @${post.username}` +
+          (post.name ? ` (${post.name})` : "") +
+          `\n` +
+          `*${formatDate(post.created_at)}*` +
+          (post.like_count ? ` | ${post.like_count} likes` : "") +
+          `\n\n` +
+          `${truncatedContent}\n\n` +
+          `---\n\n`;
+      }
+
+      if (posts.length > maxPosts) {
+        responseText += `*${posts.length - maxPosts} more posts not shown. View the full topic on VEX Forum.*\n`;
+      }
+
+      return createTextResponse(responseText);
+    } catch (error) {
+      return createErrorResponse(error, `retrieving topic ${args.topic_id}`);
+    }
+  }
+
+  /**
+   * Handles get-forum-post tool requests
+   */
+  static async handleGetForumPost(args: GetForumPostParams) {
+    try {
+      const post = await vexForumClient.getPost(args.post_id);
+
+      const content = post.raw || stripHtml(post.cooked);
+
+      // Format topic title - use slug as fallback if title not available
+      const topicDisplay = post.topic_title
+        ? post.topic_title
+        : post.topic_slug?.replace(/-/g, " ") || `Topic ${post.topic_id}`;
+
+      const responseText =
+        `**Post #${post.post_number}** in topic: **${topicDisplay}**\n` +
+        `[View on VEX Forum](https://www.vexforum.com/t/${post.topic_slug}/${post.topic_id}/${post.post_number})\n\n` +
+        `- **Author:** @${post.username}` + (post.name ? ` (${post.name})` : "") + `\n` +
+        `- **Posted:** ${formatDate(post.created_at)}\n` +
+        `- **Updated:** ${formatDate(post.updated_at)}\n` +
+        (post.like_count ? `- **Likes:** ${post.like_count}\n` : "") +
+        `- **Reply Count:** ${post.reply_count}\n\n` +
+        `---\n\n` +
+        `${content}`;
+
+      return createTextResponse(responseText);
+    } catch (error) {
+      return createErrorResponse(error, `retrieving post ${args.post_id}`);
+    }
+  }
+
+  /**
+   * Handles get-forum-user tool requests
+   */
+  static async handleGetForumUser(args: GetForumUserParams) {
+    try {
+      const response = await vexForumClient.getUser(args.username);
+      const user = response.user;
+
+      // Format time read (in seconds) to human readable
+      const formatTimeRead = (seconds?: number): string => {
+        if (!seconds) return "N/A";
+        const hours = Math.floor(seconds / 3600);
+        if (hours >= 24) {
+          const days = Math.floor(hours / 24);
+          return `${days} days`;
+        }
+        return `${hours} hours`;
+      };
+
+      let responseText =
+        `**@${user.username}**` + (user.name ? ` (${user.name})` : "") + `\n` +
+        `[View Profile](https://www.vexforum.com/u/${user.username})\n\n` +
+        (user.title ? `- **Title:** ${user.title}\n` : "") +
+        `- **Trust Level:** ${user.trust_level}\n` +
+        (user.post_count !== undefined ? `- **Posts:** ${user.post_count}\n` : "") +
+        (user.posts_read_count !== undefined ? `- **Posts Read:** ${user.posts_read_count}\n` : "") +
+        (user.days_visited !== undefined ? `- **Days Visited:** ${user.days_visited}\n` : "") +
+        `- **Badges:** ${user.badge_count || 0}\n` +
+        (user.time_read ? `- **Time Read:** ${formatTimeRead(user.time_read)}\n` : "") +
+        `- **Joined:** ${formatDate(user.created_at)}\n` +
+        `- **Last Seen:** ${formatDate(user.last_seen_at)}\n` +
+        (user.location ? `- **Location:** ${user.location}\n` : "") +
+        (user.website ? `- **Website:** ${user.website}\n` : "");
+
+      if (user.moderator || user.admin) {
+        responseText += `- **Role:** ${user.admin ? "Admin" : "Moderator"}\n`;
+      }
+
+      // Try bio_cooked first, then bio_excerpt
+      const bioContent = user.bio_cooked || (user as any).bio_excerpt;
+      if (bioContent) {
+        const bio = stripHtml(bioContent);
+        if (bio) {
+          responseText += `\n**Bio:**\n${truncateText(bio, 500)}\n`;
+        }
+      }
+
+      // Add groups if available
+      if (user.groups && user.groups.length > 0) {
+        const groupNames = user.groups
+          .filter((g) => !g.automatic)
+          .map((g) => g.name)
+          .slice(0, 10);
+        if (groupNames.length > 0) {
+          responseText += `\n**Groups:** ${groupNames.join(", ")}\n`;
+        }
+      }
+
+      return createTextResponse(responseText);
+    } catch (error) {
+      return createErrorResponse(error, `retrieving user ${args.username}`);
+    }
+  }
+
+  /**
+   * Handles list-forum-categories tool requests
+   */
+  static async handleListForumCategories(_args: ListForumCategoriesParams) {
+    try {
+      const response = await vexForumClient.getCategories();
+      const categories = response.category_list.categories;
+
+      let responseText = `**VEX Forum Categories** (${categories.length} total)\n\n`;
+
+      // Group by parent categories
+      const parentCategories = categories.filter((c) => !c.has_children || c.subcategory_ids === undefined);
+      const childCategories = new Map<number, typeof categories>();
+
+      for (const cat of categories) {
+        if (cat.subcategory_ids) {
+          for (const subId of cat.subcategory_ids) {
+            const subCat = categories.find((c) => c.id === subId);
+            if (subCat) {
+              if (!childCategories.has(cat.id)) {
+                childCategories.set(cat.id, []);
+              }
+              childCategories.get(cat.id)!.push(subCat);
+            }
+          }
+        }
+      }
+
+      for (const cat of parentCategories) {
+        responseText +=
+          `### ${cat.name}\n` +
+          `- **Slug:** ${cat.slug} | **ID:** ${cat.id}\n` +
+          `- **Topics:** ${cat.topic_count} | **Posts:** ${cat.post_count}\n` +
+          (cat.description_text ? `- ${truncateText(cat.description_text, 150)}\n` : "");
+
+        const children = childCategories.get(cat.id);
+        if (children && children.length > 0) {
+          responseText += `- **Subcategories:**\n`;
+          for (const child of children) {
+            responseText += `  - ${child.name} (${child.slug}, ID: ${child.id}) - ${child.topic_count} topics\n`;
+          }
+        }
+        responseText += "\n";
+      }
+
+      return createTextResponse(responseText);
+    } catch (error) {
+      return createErrorResponse(error, "listing forum categories");
+    }
+  }
+
+  /**
+   * Handles get-latest-forum-topics tool requests
+   */
+  static async handleGetLatestForumTopics(args: GetLatestForumTopicsParams) {
+    try {
+      const maxResults = Math.min(args.max_results || 20, 50);
+
+      let response;
+      let categoryInfo = "";
+
+      if (args.category_slug && args.category_id) {
+        response = await vexForumClient.getCategoryTopics(
+          args.category_slug,
+          args.category_id,
+          { page: args.page }
+        );
+        categoryInfo = ` in category "${args.category_slug}"`;
+      } else {
+        response = await vexForumClient.getLatestTopics({ page: args.page });
+      }
+
+      const topics = response.topic_list.topics;
+
+      if (topics.length === 0) {
+        return createTextResponse(`No topics found${categoryInfo}`);
+      }
+
+      let responseText = `**Latest Topics${categoryInfo}**\n\n`;
+
+      const displayTopics = topics.slice(0, maxResults);
+
+      for (const topic of displayTopics) {
+        responseText +=
+          `**[${topic.title}](https://www.vexforum.com/t/${topic.slug}/${topic.id})**\n` +
+          `- Views: ${topic.views} | Replies: ${topic.reply_count} | Likes: ${topic.like_count}\n` +
+          `- Last Activity: ${formatDate(topic.bumped_at)}\n` +
+          (topic.tags && topic.tags.length > 0 ? `- Tags: ${topic.tags.join(", ")}\n` : "") +
+          (topic.pinned ? `- *Pinned*\n` : "") +
+          `\n`;
+      }
+
+      if (topics.length > maxResults) {
+        responseText += `*... and ${topics.length - maxResults} more topics*\n`;
+      }
+
+      if (response.topic_list.more_topics_url) {
+        responseText += `\n*More topics available. Use page parameter to load more.*\n`;
+      }
+
+      return createTextResponse(responseText);
+    } catch (error) {
+      return createErrorResponse(error, "retrieving latest forum topics");
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import { TOOLS, TOOL_SCHEMAS, ToolName } from "./tools/index.js";
 import { TeamHandlers } from "./handlers/team-handlers.js";
 import { EventHandlers } from "./handlers/event-handlers.js";
 import { RankingHandlers } from "./handlers/ranking-handlers.js";
+import { ForumHandlers } from "./handlers/forum-handlers.js";
 
 export class VEXMCPServer {
   private server: Server;
@@ -82,6 +83,25 @@ export class VEXMCPServer {
 
           case "get-skills-scores":
             return await RankingHandlers.handleGetSkillsScores(args || {} as any);
+
+          // Forum tools
+          case "search-forum":
+            return await ForumHandlers.handleSearchForum(args as any);
+
+          case "get-forum-topic":
+            return await ForumHandlers.handleGetForumTopic(args as any);
+
+          case "get-forum-post":
+            return await ForumHandlers.handleGetForumPost(args as any);
+
+          case "get-forum-user":
+            return await ForumHandlers.handleGetForumUser(args as any);
+
+          case "list-forum-categories":
+            return await ForumHandlers.handleListForumCategories(args || {});
+
+          case "get-latest-forum-topics":
+            return await ForumHandlers.handleGetLatestForumTopics(args || {});
 
           default:
             throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/forum-tools.ts
+++ b/src/tools/forum-tools.ts
@@ -1,0 +1,188 @@
+/**
+ * VEX Forum tool definitions for MCP server
+ */
+
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+/**
+ * Tool definition for searching the VEX Forum
+ */
+export const searchForumTool: Tool = {
+  name: "search-forum",
+  description: "Search the VEX Forum (vexforum.com) for topics and posts about VEX robotics. Supports filtering by category, user, date, and sorting options.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Search query text (required)",
+      },
+      category: {
+        type: "string",
+        description: "Category slug to filter by (e.g., 'vrc-discussion', 'programming-support', 'v5-technical-support')",
+      },
+      user: {
+        type: "string",
+        description: "Username to filter posts by a specific user",
+      },
+      order: {
+        type: "string",
+        enum: ["latest", "likes", "views", "latest_topic"],
+        description: "Sort order for results",
+      },
+      before: {
+        type: "string",
+        description: "Filter results before this date (YYYY-MM-DD format)",
+      },
+      after: {
+        type: "string",
+        description: "Filter results after this date (YYYY-MM-DD format)",
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum number of results to return (default: 10, max: 50)",
+      },
+    },
+    required: ["query"],
+  },
+};
+
+/**
+ * Tool definition for getting a forum topic
+ */
+export const getForumTopicTool: Tool = {
+  name: "get-forum-topic",
+  description: "Get a VEX Forum topic by ID, including the topic details and posts/replies",
+  inputSchema: {
+    type: "object",
+    properties: {
+      topic_id: {
+        type: "number",
+        description: "The topic ID to retrieve",
+      },
+      max_posts: {
+        type: "number",
+        description: "Maximum number of posts to include (default: 10, max: 50)",
+      },
+      include_raw: {
+        type: "boolean",
+        description: "Include raw markdown content in addition to HTML (default: false)",
+      },
+    },
+    required: ["topic_id"],
+  },
+};
+
+/**
+ * Tool definition for getting a single forum post
+ */
+export const getForumPostTool: Tool = {
+  name: "get-forum-post",
+  description: "Get a single VEX Forum post by its ID",
+  inputSchema: {
+    type: "object",
+    properties: {
+      post_id: {
+        type: "number",
+        description: "The post ID to retrieve",
+      },
+    },
+    required: ["post_id"],
+  },
+};
+
+/**
+ * Tool definition for getting forum user profile
+ */
+export const getForumUserTool: Tool = {
+  name: "get-forum-user",
+  description: "Get a VEX Forum user's profile information by username",
+  inputSchema: {
+    type: "object",
+    properties: {
+      username: {
+        type: "string",
+        description: "The username to look up",
+      },
+    },
+    required: ["username"],
+  },
+};
+
+/**
+ * Tool definition for listing forum categories
+ */
+export const listForumCategoriesTool: Tool = {
+  name: "list-forum-categories",
+  description: "List all categories available on the VEX Forum",
+  inputSchema: {
+    type: "object",
+    properties: {},
+  },
+};
+
+/**
+ * Tool definition for getting latest forum topics
+ */
+export const getLatestForumTopicsTool: Tool = {
+  name: "get-latest-forum-topics",
+  description: "Get the latest topics from the VEX Forum, optionally filtered by category",
+  inputSchema: {
+    type: "object",
+    properties: {
+      category_slug: {
+        type: "string",
+        description: "Category slug to filter by (e.g., 'vrc-discussion', 'programming-support')",
+      },
+      category_id: {
+        type: "number",
+        description: "Category ID to filter by (required if category_slug is provided)",
+      },
+      page: {
+        type: "number",
+        description: "Page number for pagination (default: 0)",
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum number of topics to return (default: 20, max: 50)",
+      },
+    },
+  },
+};
+
+/**
+ * Zod schemas for parameter validation
+ */
+export const SearchForumParamsSchema = z.object({
+  query: z.string().min(1, "Search query is required"),
+  category: z.string().optional(),
+  user: z.string().optional(),
+  order: z.enum(["latest", "likes", "views", "latest_topic"]).optional(),
+  before: z.string().optional(),
+  after: z.string().optional(),
+  max_results: z.number().int().min(1).max(50).optional(),
+});
+
+export const GetForumTopicParamsSchema = z.object({
+  topic_id: z.number().int().positive("Topic ID must be a positive integer"),
+  max_posts: z.number().int().min(1).max(50).optional(),
+  include_raw: z.boolean().optional(),
+});
+
+export const GetForumPostParamsSchema = z.object({
+  post_id: z.number().int().positive("Post ID must be a positive integer"),
+});
+
+export const GetForumUserParamsSchema = z.object({
+  username: z.string().min(1, "Username is required"),
+});
+
+export const ListForumCategoriesParamsSchema = z.object({});
+
+export const GetLatestForumTopicsParamsSchema = z.object({
+  category_slug: z.string().optional(),
+  category_id: z.number().int().positive().optional(),
+  page: z.number().int().min(0).optional(),
+  max_results: z.number().int().min(1).max(50).optional(),
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,46 +8,82 @@ import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { searchTeamsTool, getTeamInfoTool } from "./team-tools.js";
 import { searchEventsTool, getEventDetailsTool, getEventAwardsTool } from "./event-tools.js";
 import { getTeamRankingsTool, getSkillsScoresTool } from "./ranking-tools.js";
+import {
+  searchForumTool,
+  getForumTopicTool,
+  getForumPostTool,
+  getForumUserTool,
+  listForumCategoriesTool,
+  getLatestForumTopicsTool,
+} from "./forum-tools.js";
 
 // Import validation schemas
-import { 
-  SearchTeamsParamsSchema, 
-  GetTeamInfoParamsSchema 
+import {
+  SearchTeamsParamsSchema,
+  GetTeamInfoParamsSchema
 } from "./team-tools.js";
-import { 
-  SearchEventsParamsSchema, 
+import {
+  SearchEventsParamsSchema,
   GetEventDetailsParamsSchema,
   GetEventAwardsParamsSchema
 } from "./event-tools.js";
-import { 
-  GetTeamRankingsParamsSchema, 
-  GetSkillsScoresParamsSchema 
+import {
+  GetTeamRankingsParamsSchema,
+  GetSkillsScoresParamsSchema
 } from "./ranking-tools.js";
+import {
+  SearchForumParamsSchema,
+  GetForumTopicParamsSchema,
+  GetForumPostParamsSchema,
+  GetForumUserParamsSchema,
+  ListForumCategoriesParamsSchema,
+  GetLatestForumTopicsParamsSchema,
+} from "./forum-tools.js";
 
 /**
  * All available MCP tools
  */
 export const TOOLS: Tool[] = [
+  // Team tools
   searchTeamsTool,
   getTeamInfoTool,
+  // Event tools
   searchEventsTool,
   getEventDetailsTool,
   getEventAwardsTool,
+  // Ranking tools
   getTeamRankingsTool,
   getSkillsScoresTool,
+  // Forum tools
+  searchForumTool,
+  getForumTopicTool,
+  getForumPostTool,
+  getForumUserTool,
+  listForumCategoriesTool,
+  getLatestForumTopicsTool,
 ];
 
 /**
  * Validation schemas mapped by tool name
  */
 export const TOOL_SCHEMAS = {
+  // Team tools
   "search-teams": SearchTeamsParamsSchema,
   "get-team-info": GetTeamInfoParamsSchema,
+  // Event tools
   "search-events": SearchEventsParamsSchema,
   "get-event-details": GetEventDetailsParamsSchema,
   "get-event-awards": GetEventAwardsParamsSchema,
+  // Ranking tools
   "get-team-rankings": GetTeamRankingsParamsSchema,
   "get-skills-scores": GetSkillsScoresParamsSchema,
+  // Forum tools
+  "search-forum": SearchForumParamsSchema,
+  "get-forum-topic": GetForumTopicParamsSchema,
+  "get-forum-post": GetForumPostParamsSchema,
+  "get-forum-user": GetForumUserParamsSchema,
+  "list-forum-categories": ListForumCategoriesParamsSchema,
+  "get-latest-forum-topics": GetLatestForumTopicsParamsSchema,
 } as const;
 
 /**

--- a/src/utils/cloudscraper_helper.py
+++ b/src/utils/cloudscraper_helper.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Cloudscraper helper script for bypassing Cloudflare protection.
+This script is called by the Node.js server to make HTTP requests to protected sites.
+"""
+
+import sys
+import json
+import cloudscraper
+
+def main():
+    """Read request from stdin, make request, write response to stdout."""
+    try:
+        # Read JSON input from stdin
+        input_data = json.loads(sys.stdin.read())
+
+        url = input_data.get('url')
+        method = input_data.get('method', 'GET').upper()
+        headers = input_data.get('headers', {})
+        params = input_data.get('params', {})
+        data = input_data.get('data')
+        timeout = input_data.get('timeout', 30)
+
+        if not url:
+            raise ValueError("URL is required")
+
+        # Create cloudscraper session
+        scraper = cloudscraper.create_scraper(
+            browser={
+                'browser': 'chrome',
+                'platform': 'windows',
+                'desktop': True
+            }
+        )
+
+        # Make request based on method
+        if method == 'GET':
+            response = scraper.get(url, headers=headers, params=params, timeout=timeout)
+        elif method == 'POST':
+            response = scraper.post(url, headers=headers, params=params, json=data, timeout=timeout)
+        else:
+            raise ValueError(f"Unsupported method: {method}")
+
+        # Build response object
+        result = {
+            'status': response.status_code,
+            'ok': response.ok,
+            'headers': dict(response.headers),
+            'url': response.url,
+        }
+
+        # Try to parse as JSON, otherwise return text
+        try:
+            result['data'] = response.json()
+            result['isJson'] = True
+        except (json.JSONDecodeError, ValueError):
+            result['data'] = response.text
+            result['isJson'] = False
+
+        # Output JSON response
+        print(json.dumps(result))
+
+    except Exception as e:
+        # Output error as JSON
+        error_result = {
+            'error': True,
+            'message': str(e),
+            'type': type(e).__name__
+        }
+        print(json.dumps(error_result))
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/src/utils/discourse-client.ts
+++ b/src/utils/discourse-client.ts
@@ -1,0 +1,627 @@
+/**
+ * Discourse API client using cloudscraper for Cloudflare bypass
+ */
+
+import { spawn } from "child_process";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Get the project root directory (go up from build/utils or src/utils)
+const projectRoot = path.resolve(__dirname, "..", "..");
+
+interface CloudscraperRequest {
+  url: string;
+  method?: "GET" | "POST";
+  headers?: Record<string, string>;
+  params?: Record<string, string | number>;
+  data?: unknown;
+  timeout?: number;
+}
+
+interface CloudscraperResponse {
+  status: number;
+  ok: boolean;
+  headers: Record<string, string>;
+  url: string;
+  data: unknown;
+  isJson: boolean;
+  error?: boolean;
+  message?: string;
+}
+
+/**
+ * Execute a request using the Python cloudscraper helper
+ */
+async function executeCloudscraperRequest(
+  request: CloudscraperRequest
+): Promise<CloudscraperResponse> {
+  return new Promise((resolve, reject) => {
+    // Python script is in src/utils/, not build/utils/
+    const pythonScript = path.join(projectRoot, "src", "utils", "cloudscraper_helper.py");
+
+    const pythonProcess = spawn("python3", [pythonScript], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    pythonProcess.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    pythonProcess.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    pythonProcess.on("close", (code) => {
+      if (code !== 0) {
+        try {
+          const errorData = JSON.parse(stdout);
+          reject(new Error(errorData.message || `Python process exited with code ${code}`));
+        } catch {
+          reject(new Error(stderr || `Python process exited with code ${code}`));
+        }
+        return;
+      }
+
+      try {
+        const response = JSON.parse(stdout);
+        if (response.error) {
+          reject(new Error(response.message));
+        } else {
+          resolve(response);
+        }
+      } catch (e) {
+        reject(new Error(`Failed to parse response: ${stdout}`));
+      }
+    });
+
+    pythonProcess.on("error", (err) => {
+      reject(new Error(`Failed to spawn Python process: ${err.message}`));
+    });
+
+    // Send request data to stdin
+    pythonProcess.stdin.write(JSON.stringify(request));
+    pythonProcess.stdin.end();
+  });
+}
+
+/**
+ * VEX Forum Discourse API Client
+ */
+export class DiscourseClient {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = "https://www.vexforum.com") {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+  }
+
+  /**
+   * Make a GET request to the Discourse API
+   */
+  async get<T = unknown>(
+    endpoint: string,
+    params?: Record<string, string | number>
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await executeCloudscraperRequest({
+      url,
+      method: "GET",
+      params,
+      timeout: 30,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: Request to ${endpoint} failed`);
+    }
+
+    return response.data as T;
+  }
+
+  /**
+   * Search the forum
+   */
+  async search(query: string, options?: {
+    category?: string | number;
+    user?: string;
+    order?: "latest" | "likes" | "views" | "latest_topic";
+    status?: "open" | "closed" | "archived" | "noreplies" | "single_user";
+    min_posts?: number;
+    max_posts?: number;
+    before?: string;
+    after?: string;
+  }): Promise<DiscourseSearchResult> {
+    // Build search query string
+    let searchQuery = query;
+
+    if (options?.category) {
+      searchQuery += ` #${options.category}`;
+    }
+    if (options?.user) {
+      searchQuery += ` @${options.user}`;
+    }
+    if (options?.order) {
+      searchQuery += ` order:${options.order}`;
+    }
+    if (options?.status) {
+      searchQuery += ` status:${options.status}`;
+    }
+    if (options?.min_posts) {
+      searchQuery += ` min_posts:${options.min_posts}`;
+    }
+    if (options?.max_posts) {
+      searchQuery += ` max_posts:${options.max_posts}`;
+    }
+    if (options?.before) {
+      searchQuery += ` before:${options.before}`;
+    }
+    if (options?.after) {
+      searchQuery += ` after:${options.after}`;
+    }
+
+    return this.get<DiscourseSearchResult>("/search.json", { q: searchQuery });
+  }
+
+  /**
+   * Get a topic by ID
+   */
+  async getTopic(topicId: number, options?: {
+    post_number?: number;
+    include_raw?: boolean;
+  }): Promise<DiscourseTopic> {
+    const params: Record<string, string | number> = {};
+    if (options?.include_raw) {
+      params.include_raw = 1;
+    }
+    if (options?.post_number) {
+      params.post_number = options.post_number;
+    }
+    return this.get<DiscourseTopic>(`/t/${topicId}.json`, params);
+  }
+
+  /**
+   * Get a single post by ID
+   */
+  async getPost(postId: number): Promise<DiscoursePost> {
+    return this.get<DiscoursePost>(`/posts/${postId}.json`);
+  }
+
+  /**
+   * Get user profile by username
+   */
+  async getUser(username: string): Promise<DiscourseUserResponse> {
+    return this.get<DiscourseUserResponse>(`/u/${username}.json`);
+  }
+
+  /**
+   * Get all categories
+   */
+  async getCategories(): Promise<DiscourseCategoriesResponse> {
+    return this.get<DiscourseCategoriesResponse>("/categories.json");
+  }
+
+  /**
+   * Get latest topics
+   */
+  async getLatestTopics(options?: {
+    page?: number;
+    order?: string;
+  }): Promise<DiscourseTopicListResponse> {
+    const params: Record<string, string | number> = {};
+    if (options?.page) {
+      params.page = options.page;
+    }
+    if (options?.order) {
+      params.order = options.order;
+    }
+    return this.get<DiscourseTopicListResponse>("/latest.json", params);
+  }
+
+  /**
+   * Get topics from a specific category
+   */
+  async getCategoryTopics(
+    categorySlug: string,
+    categoryId: number,
+    options?: { page?: number }
+  ): Promise<DiscourseTopicListResponse> {
+    const params: Record<string, string | number> = {};
+    if (options?.page) {
+      params.page = options.page;
+    }
+    return this.get<DiscourseTopicListResponse>(
+      `/c/${categorySlug}/${categoryId}.json`,
+      params
+    );
+  }
+}
+
+// Type definitions for Discourse API responses
+
+export interface DiscourseSearchResult {
+  posts?: DiscourseSearchPost[];
+  topics?: DiscourseSearchTopic[];
+  users?: DiscourseSearchUser[];
+  grouped_search_result?: {
+    more_posts: boolean;
+    more_users: boolean;
+    more_categories: boolean;
+    term: string;
+    search_log_id: number;
+    more_full_page_results: boolean;
+    can_create_topic: boolean;
+    error: string | null;
+    post_ids: number[];
+    user_ids: number[];
+    category_ids: number[];
+    tag_ids: number[];
+    group_ids: number[];
+  };
+}
+
+export interface DiscourseSearchPost {
+  id: number;
+  name: string;
+  username: string;
+  avatar_template: string;
+  created_at: string;
+  like_count: number;
+  blurb: string;
+  post_number: number;
+  topic_title_headline: string;
+  topic_id: number;
+}
+
+export interface DiscourseSearchTopic {
+  id: number;
+  title: string;
+  fancy_title: string;
+  slug: string;
+  posts_count: number;
+  reply_count: number;
+  highest_post_number: number;
+  created_at: string;
+  last_posted_at: string;
+  bumped: boolean;
+  bumped_at: string;
+  archetype: string;
+  unseen: boolean;
+  pinned: boolean;
+  visible: boolean;
+  closed: boolean;
+  archived: boolean;
+  views: number;
+  like_count: number;
+  category_id: number;
+  tags?: string[];
+}
+
+export interface DiscourseSearchUser {
+  id: number;
+  username: string;
+  name: string;
+  avatar_template: string;
+}
+
+export interface DiscourseTopic {
+  id: number;
+  title: string;
+  fancy_title: string;
+  slug: string;
+  posts_count: number;
+  reply_count: number;
+  highest_post_number: number;
+  created_at: string;
+  last_posted_at: string;
+  bumped: boolean;
+  bumped_at: string;
+  archetype: string;
+  pinned: boolean;
+  visible: boolean;
+  closed: boolean;
+  archived: boolean;
+  views: number;
+  like_count: number;
+  category_id: number;
+  tags?: string[];
+  post_stream?: {
+    posts: DiscourseTopicPost[];
+    stream?: number[];
+  };
+  details?: {
+    auto_close_at: string | null;
+    auto_close_hours: number | null;
+    auto_close_based_on_last_post: boolean;
+    created_by: {
+      id: number;
+      username: string;
+      name: string;
+      avatar_template: string;
+    };
+    last_poster: {
+      id: number;
+      username: string;
+      name: string;
+      avatar_template: string;
+    };
+    participants: Array<{
+      id: number;
+      username: string;
+      name: string;
+      avatar_template: string;
+      post_count: number;
+    }>;
+    links?: Array<{
+      url: string;
+      title: string;
+      internal: boolean;
+      attachment: boolean;
+      reflection: boolean;
+      clicks: number;
+      user_id: number;
+      domain: string;
+    }>;
+  };
+}
+
+export interface DiscourseTopicPost {
+  id: number;
+  name: string;
+  username: string;
+  avatar_template: string;
+  created_at: string;
+  cooked: string;
+  raw?: string;
+  post_number: number;
+  post_type: number;
+  updated_at: string;
+  reply_count: number;
+  reply_to_post_number: number | null;
+  quote_count: number;
+  incoming_link_count: number;
+  reads: number;
+  readers_count: number;
+  score: number;
+  yours: boolean;
+  topic_id: number;
+  topic_slug: string;
+  primary_group_name: string | null;
+  flair_name: string | null;
+  flair_url: string | null;
+  flair_bg_color: string | null;
+  flair_color: string | null;
+  version: number;
+  can_edit: boolean;
+  can_delete: boolean;
+  can_recover: boolean;
+  can_wiki: boolean;
+  user_title: string | null;
+  actions_summary?: Array<{
+    id: number;
+    count: number;
+    acted?: boolean;
+  }>;
+  moderator: boolean;
+  admin: boolean;
+  staff: boolean;
+  user_id: number;
+  hidden: boolean;
+  trust_level: number;
+  deleted_at: string | null;
+  user_deleted: boolean;
+  edit_reason: string | null;
+  can_view_edit_history: boolean;
+  wiki: boolean;
+  like_count?: number;
+}
+
+export interface DiscoursePost {
+  id: number;
+  name: string;
+  username: string;
+  avatar_template: string;
+  created_at: string;
+  cooked: string;
+  raw?: string;
+  post_number: number;
+  post_type: number;
+  updated_at: string;
+  reply_count: number;
+  reply_to_post_number: number | null;
+  topic_id: number;
+  topic_slug: string;
+  topic_title: string;
+  topic_html_title: string;
+  category_id: number;
+  user_id: number;
+  like_count?: number;
+}
+
+export interface DiscourseUserResponse {
+  user: DiscourseUser;
+}
+
+export interface DiscourseUser {
+  id: number;
+  username: string;
+  name: string;
+  avatar_template: string;
+  title: string | null;
+  last_posted_at: string;
+  last_seen_at: string;
+  created_at: string;
+  trust_level: number;
+  moderator: boolean;
+  admin: boolean;
+  post_count: number;
+  posts_read_count: number;
+  days_visited: number;
+  badge_count: number;
+  time_read: number;
+  recent_time_read: number;
+  primary_group_id: number | null;
+  primary_group_name: string | null;
+  flair_name: string | null;
+  flair_url: string | null;
+  flair_bg_color: string | null;
+  flair_color: string | null;
+  bio_raw?: string;
+  bio_cooked?: string;
+  website?: string;
+  website_name?: string;
+  location?: string;
+  profile_view_count?: number;
+  invited_by?: {
+    id: number;
+    username: string;
+    name: string;
+    avatar_template: string;
+  };
+  groups?: Array<{
+    id: number;
+    automatic: boolean;
+    name: string;
+    display_name: string;
+    user_count: number;
+    mentionable_level: number;
+    messageable_level: number;
+    visibility_level: number;
+    primary_group: boolean;
+    title: string | null;
+    grant_trust_level: number | null;
+    incoming_email: string | null;
+    has_messages: boolean;
+    flair_url: string | null;
+    flair_bg_color: string | null;
+    flair_color: string | null;
+    bio_raw: string | null;
+    bio_cooked: string | null;
+    public_admission: boolean;
+    public_exit: boolean;
+    allow_membership_requests: boolean;
+    full_name: string | null;
+  }>;
+  user_fields?: Record<string, string>;
+}
+
+export interface DiscourseCategoriesResponse {
+  category_list: {
+    can_create_category: boolean;
+    can_create_topic: boolean;
+    categories: DiscourseCategory[];
+  };
+}
+
+export interface DiscourseCategory {
+  id: number;
+  name: string;
+  color: string;
+  text_color: string;
+  slug: string;
+  topic_count: number;
+  post_count: number;
+  position: number;
+  description: string;
+  description_text: string;
+  topic_url: string;
+  read_restricted: boolean;
+  permission: number;
+  notification_level: number;
+  can_edit: boolean;
+  topic_template: string | null;
+  has_children: boolean;
+  sort_order: string | null;
+  sort_ascending: boolean | null;
+  show_subcategory_list: boolean;
+  num_featured_topics: number;
+  default_view: string | null;
+  subcategory_list_style: string;
+  default_top_period: string;
+  default_list_filter: string;
+  minimum_required_tags: number;
+  navigate_to_first_post_after_read: boolean;
+  topics_day: number;
+  topics_week: number;
+  topics_month: number;
+  topics_year: number;
+  topics_all_time: number;
+  is_uncategorized: boolean;
+  subcategory_ids?: number[];
+  uploaded_logo?: {
+    id: number;
+    url: string;
+    width: number;
+    height: number;
+  };
+  uploaded_background?: {
+    id: number;
+    url: string;
+    width: number;
+    height: number;
+  };
+}
+
+export interface DiscourseTopicListResponse {
+  users?: DiscourseSearchUser[];
+  primary_groups?: unknown[];
+  flair_groups?: unknown[];
+  topic_list: {
+    can_create_topic: boolean;
+    more_topics_url?: string;
+    per_page: number;
+    top_tags?: string[];
+    topics: DiscourseTopicListItem[];
+  };
+}
+
+export interface DiscourseTopicListItem {
+  id: number;
+  title: string;
+  fancy_title: string;
+  slug: string;
+  posts_count: number;
+  reply_count: number;
+  highest_post_number: number;
+  image_url: string | null;
+  created_at: string;
+  last_posted_at: string;
+  bumped: boolean;
+  bumped_at: string;
+  archetype: string;
+  unseen: boolean;
+  last_read_post_number?: number;
+  unread?: number;
+  new_posts?: number;
+  unread_posts?: number;
+  pinned: boolean;
+  unpinned: boolean | null;
+  visible: boolean;
+  closed: boolean;
+  archived: boolean;
+  notification_level?: number;
+  bookmarked?: boolean;
+  liked?: boolean;
+  tags?: string[];
+  views: number;
+  like_count: number;
+  has_summary: boolean;
+  last_poster_username: string;
+  category_id: number;
+  pinned_globally: boolean;
+  featured_link: string | null;
+  has_accepted_answer?: boolean;
+  posters: Array<{
+    extras: string | null;
+    description: string;
+    user_id: number;
+    primary_group_id: number | null;
+    flair_group_id: number | null;
+  }>;
+}
+
+// Export singleton instance for VEX Forum
+export const vexForumClient = new DiscourseClient("https://www.vexforum.com");

--- a/tests/test-forum-comprehensive.mjs
+++ b/tests/test-forum-comprehensive.mjs
@@ -1,0 +1,191 @@
+/**
+ * Comprehensive test script for VEX Forum tools
+ */
+
+import { ForumHandlers } from "../build/handlers/forum-handlers.js";
+
+// Helper to add delay between tests to avoid rate limiting
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Helper to check if response contains actual data (not error)
+function isSuccessResponse(result) {
+  const text = result?.content?.[0]?.text || "";
+  return text && !text.startsWith("Error ");
+}
+
+async function runTests() {
+  console.log("=".repeat(70));
+  console.log("VEX Forum Tools - Comprehensive Test Suite");
+  console.log("=".repeat(70));
+  console.log("Testing all 6 forum tools with real API calls...\n");
+
+  let passed = 0;
+  let failed = 0;
+  const results = [];
+
+  // Test 1: Search Forum
+  console.log("[1/6] search-forum");
+  console.log("     Query: 'PID tuning'");
+  try {
+    const result = await ForumHandlers.handleSearchForum({
+      query: "PID tuning",
+      max_results: 5,
+    });
+    if (isSuccessResponse(result)) {
+      console.log("     ✓ PASSED");
+      console.log("     Response preview:");
+      console.log("     " + result.content[0].text.split("\n").slice(0, 5).join("\n     "));
+      passed++;
+      results.push({ test: "search-forum", status: "passed" });
+    } else {
+      throw new Error(result.content[0]?.text || "No response");
+    }
+  } catch (e) {
+    console.log("     ✗ FAILED:", e.message);
+    failed++;
+    results.push({ test: "search-forum", status: "failed", error: e.message });
+  }
+
+  await delay(2000); // Wait to avoid rate limiting
+
+  // Test 2: Get Forum Topic
+  console.log("\n[2/6] get-forum-topic");
+  console.log("     Topic ID: 76173 (LCD screen autonomous code issue)");
+  try {
+    const result = await ForumHandlers.handleGetForumTopic({
+      topic_id: 76173,
+      max_posts: 3,
+    });
+    if (isSuccessResponse(result)) {
+      console.log("     ✓ PASSED");
+      console.log("     Response preview:");
+      console.log("     " + result.content[0].text.split("\n").slice(0, 6).join("\n     "));
+      passed++;
+      results.push({ test: "get-forum-topic", status: "passed" });
+    } else {
+      throw new Error(result.content[0]?.text || "No response");
+    }
+  } catch (e) {
+    console.log("     ✗ FAILED:", e.message);
+    failed++;
+    results.push({ test: "get-forum-topic", status: "failed", error: e.message });
+  }
+
+  await delay(2000);
+
+  // Test 3: Get Forum Post
+  console.log("\n[3/6] get-forum-post");
+  console.log("     Post ID: 358147");
+  try {
+    const result = await ForumHandlers.handleGetForumPost({
+      post_id: 358147,
+    });
+    if (isSuccessResponse(result)) {
+      console.log("     ✓ PASSED");
+      console.log("     Response preview:");
+      console.log("     " + result.content[0].text.split("\n").slice(0, 6).join("\n     "));
+      passed++;
+      results.push({ test: "get-forum-post", status: "passed" });
+    } else {
+      throw new Error(result.content[0]?.text || "No response");
+    }
+  } catch (e) {
+    console.log("     ✗ FAILED:", e.message);
+    failed++;
+    results.push({ test: "get-forum-post", status: "failed", error: e.message });
+  }
+
+  await delay(2000);
+
+  // Test 4: Get Forum User
+  console.log("\n[4/6] get-forum-user");
+  console.log("     Username: jpearman (well-known community member)");
+  try {
+    const result = await ForumHandlers.handleGetForumUser({
+      username: "jpearman",
+    });
+    if (isSuccessResponse(result)) {
+      console.log("     ✓ PASSED");
+      console.log("     Response preview:");
+      console.log("     " + result.content[0].text.split("\n").slice(0, 8).join("\n     "));
+      passed++;
+      results.push({ test: "get-forum-user", status: "passed" });
+    } else {
+      throw new Error(result.content[0]?.text || "No response");
+    }
+  } catch (e) {
+    console.log("     ✗ FAILED:", e.message);
+    failed++;
+    results.push({ test: "get-forum-user", status: "failed", error: e.message });
+  }
+
+  await delay(2000);
+
+  // Test 5: List Forum Categories
+  console.log("\n[5/6] list-forum-categories");
+  try {
+    const result = await ForumHandlers.handleListForumCategories({});
+    if (isSuccessResponse(result)) {
+      console.log("     ✓ PASSED");
+      console.log("     Response preview:");
+      console.log("     " + result.content[0].text.split("\n").slice(0, 8).join("\n     "));
+      passed++;
+      results.push({ test: "list-forum-categories", status: "passed" });
+    } else {
+      throw new Error(result.content[0]?.text || "No response");
+    }
+  } catch (e) {
+    console.log("     ✗ FAILED:", e.message);
+    failed++;
+    results.push({ test: "list-forum-categories", status: "failed", error: e.message });
+  }
+
+  await delay(2000);
+
+  // Test 6: Get Latest Forum Topics
+  console.log("\n[6/6] get-latest-forum-topics");
+  try {
+    const result = await ForumHandlers.handleGetLatestForumTopics({
+      max_results: 5,
+    });
+    if (isSuccessResponse(result)) {
+      console.log("     ✓ PASSED");
+      console.log("     Response preview:");
+      console.log("     " + result.content[0].text.split("\n").slice(0, 6).join("\n     "));
+      passed++;
+      results.push({ test: "get-latest-forum-topics", status: "passed" });
+    } else {
+      throw new Error(result.content[0]?.text || "No response");
+    }
+  } catch (e) {
+    console.log("     ✗ FAILED:", e.message);
+    failed++;
+    results.push({ test: "get-latest-forum-topics", status: "failed", error: e.message });
+  }
+
+  // Summary
+  console.log("\n" + "=".repeat(70));
+  console.log("TEST RESULTS SUMMARY");
+  console.log("=".repeat(70));
+  console.log(`Total: ${passed + failed} tests`);
+  console.log(`Passed: ${passed} ✓`);
+  console.log(`Failed: ${failed} ✗`);
+  console.log("");
+
+  if (failed > 0) {
+    console.log("Failed tests:");
+    results.filter((r) => r.status === "failed").forEach((r) => {
+      console.log(`  - ${r.test}: ${r.error}`);
+    });
+  }
+
+  console.log("=".repeat(70));
+
+  // Exit with appropriate code
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests().catch((e) => {
+  console.error("Test suite error:", e);
+  process.exit(1);
+});

--- a/tests/test-forum.mjs
+++ b/tests/test-forum.mjs
@@ -1,0 +1,140 @@
+/**
+ * Test script for VEX Forum tools
+ */
+
+import { vexForumClient } from "../build/utils/discourse-client.js";
+import { ForumHandlers } from "../build/handlers/forum-handlers.js";
+
+async function runTests() {
+  console.log("=".repeat(60));
+  console.log("VEX Forum Tools Test Suite");
+  console.log("=".repeat(60));
+
+  let passed = 0;
+  let failed = 0;
+
+  // Test 1: Search Forum
+  console.log("\n[Test 1] Search Forum - 'autonomous programming'");
+  try {
+    const result = await ForumHandlers.handleSearchForum({
+      query: "autonomous programming",
+      max_results: 5,
+    });
+    if (result.content && result.content[0]?.text) {
+      console.log("✓ PASSED - Search returned results");
+      console.log("  Preview:", result.content[0].text.substring(0, 200) + "...");
+      passed++;
+    } else {
+      throw new Error("No content returned");
+    }
+  } catch (e) {
+    console.log("✗ FAILED:", e.message);
+    failed++;
+  }
+
+  // Test 2: Get Forum Topic
+  console.log("\n[Test 2] Get Forum Topic - ID 76173");
+  try {
+    const result = await ForumHandlers.handleGetForumTopic({
+      topic_id: 76173,
+      max_posts: 3,
+    });
+    if (result.content && result.content[0]?.text) {
+      console.log("✓ PASSED - Topic retrieved");
+      console.log("  Preview:", result.content[0].text.substring(0, 200) + "...");
+      passed++;
+    } else {
+      throw new Error("No content returned");
+    }
+  } catch (e) {
+    console.log("✗ FAILED:", e.message);
+    failed++;
+  }
+
+  // Test 3: Get Forum User
+  console.log("\n[Test 3] Get Forum User - 'jpearman'");
+  try {
+    const result = await ForumHandlers.handleGetForumUser({
+      username: "jpearman",
+    });
+    if (result.content && result.content[0]?.text) {
+      console.log("✓ PASSED - User retrieved");
+      console.log("  Preview:", result.content[0].text.substring(0, 200) + "...");
+      passed++;
+    } else {
+      throw new Error("No content returned");
+    }
+  } catch (e) {
+    console.log("✗ FAILED:", e.message);
+    failed++;
+  }
+
+  // Test 4: List Forum Categories
+  console.log("\n[Test 4] List Forum Categories");
+  try {
+    const result = await ForumHandlers.handleListForumCategories({});
+    if (result.content && result.content[0]?.text) {
+      console.log("✓ PASSED - Categories listed");
+      console.log("  Preview:", result.content[0].text.substring(0, 200) + "...");
+      passed++;
+    } else {
+      throw new Error("No content returned");
+    }
+  } catch (e) {
+    console.log("✗ FAILED:", e.message);
+    failed++;
+  }
+
+  // Test 5: Get Latest Forum Topics
+  console.log("\n[Test 5] Get Latest Forum Topics");
+  try {
+    const result = await ForumHandlers.handleGetLatestForumTopics({
+      max_results: 5,
+    });
+    if (result.content && result.content[0]?.text) {
+      console.log("✓ PASSED - Latest topics retrieved");
+      console.log("  Preview:", result.content[0].text.substring(0, 200) + "...");
+      passed++;
+    } else {
+      throw new Error("No content returned");
+    }
+  } catch (e) {
+    console.log("✗ FAILED:", e.message);
+    failed++;
+  }
+
+  // Test 6: Search with filters
+  console.log("\n[Test 6] Search Forum with category filter");
+  try {
+    const result = await ForumHandlers.handleSearchForum({
+      query: "motor",
+      category: "vrc-discussion",
+      order: "latest",
+      max_results: 3,
+    });
+    if (result.content && result.content[0]?.text) {
+      console.log("✓ PASSED - Filtered search returned results");
+      console.log("  Preview:", result.content[0].text.substring(0, 200) + "...");
+      passed++;
+    } else {
+      throw new Error("No content returned");
+    }
+  } catch (e) {
+    console.log("✗ FAILED:", e.message);
+    failed++;
+  }
+
+  // Summary
+  console.log("\n" + "=".repeat(60));
+  console.log(`Test Results: ${passed} passed, ${failed} failed`);
+  console.log("=".repeat(60));
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+runTests().catch((e) => {
+  console.error("Test suite error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
Add support for accessing VEX Forum (vexforum.com) via Discourse API:

New tools:
- search-forum: Search forum with filters (category, user, date, order)
- get-forum-topic: Get topic details and posts by ID
- get-forum-post: Get single post by ID
- get-forum-user: Get user profile by username
- list-forum-categories: List all forum categories
- get-latest-forum-topics: Get latest topics, optionally by category

Implementation details:
- Uses cloudscraper Python library to bypass Cloudflare protection
- Includes comprehensive TypeScript types for Discourse API responses
- Handles rate limiting gracefully with error responses
- No authentication required for read-only forum access

New files:
- src/utils/cloudscraper_helper.py - Python Cloudflare bypass script
- src/utils/discourse-client.ts - Discourse API client
- src/tools/forum-tools.ts - Tool definitions and Zod schemas
- src/handlers/forum-handlers.ts - Request handlers
- tests/test-forum.mjs - Basic test suite
- tests/test-forum-comprehensive.mjs - Full test suite